### PR TITLE
Mitigate unauthenticated protocol-state confusion and denial of service Eap payload

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -153,11 +153,24 @@ func (p *Packet) handleEAP(pp protocol.Payload, stm protocol.StateManager, paren
 		MsgType: t,
 	}
 	var payload any
-	if reflect.TypeOf(pp.(*eap.Payload).Payload) == reflect.TypeOf(np) {
-		err := np.Decode(pp.(*eap.Payload).RawPayload)
-		if err != nil {
-			ctx.log.Warn("failed to decode payload", "error", err)
-		}
+	incomingType := reflect.TypeOf(pp.(*eap.Payload).Payload)
+	expectedType := reflect.TypeOf(np)
+	// Reject type mismatch: incoming payload must match expected protocol type
+	if incomingType != expectedType {
+		ctx.log.Warn("protocol type mismatch", "expected", expectedType, "received", incomingType)
+		return &eap.Payload{
+			Code: protocol.CodeFailure,
+			ID:   p.eap.ID,
+		}, nil
+	}
+	// Decode the payload and reject on error
+	err = np.Decode(pp.(*eap.Payload).RawPayload)
+	if err != nil {
+		ctx.log.Warn("failed to decode payload", "error", err)
+		return &eap.Payload{
+			Code: protocol.CodeFailure,
+			ID:   p.eap.ID,
+		}, nil
 	}
 	payload = np.Handle(ctx)
 	if payload != nil {

--- a/protocol/mschapv2/op_response.go
+++ b/protocol/mschapv2/op_response.go
@@ -12,6 +12,11 @@ type Response struct {
 }
 
 func ParseResponse(raw []byte) (*Response, error) {
+	// Validate minimum length before slicing
+	minLength := challengeValueSize + responseReservedSize + responseNTResponseSize + 1
+	if len(raw) < minLength {
+		return nil, errors.New("MSCHAPv2: response too short")
+	}
 	res := &Response{}
 	res.Challenge = raw[:challengeValueSize]
 	if !bytes.Equal(raw[challengeValueSize:challengeValueSize+responseReservedSize], make([]byte, 8)) {


### PR DESCRIPTION
This patch proposes a mitigation for unauthenticated protocol-state confusion and denial of service by enforcing strict EAP payload type matching and decode validation in the dispatcher, rejecting mismatched protocol types and decode errors before invoking handlers, and adding length validation to MSCHAPv2 response parsing to prevent panic on malformed input.